### PR TITLE
Fix issue in `test_rmsnorm.py` that fails on Keras 3.6.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5340,4 +5340,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "c691b4f7e9d3ca1a7d49ba0ddb0a0d01011f3f6a9519083ca087ad76b4106fb4"
+content-hash = "1f1387dfcfa762fed5e147c5f0cea069499a2064574c5309c03a417ba1a756b7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [{ include = "keras_mml" }]
 python = ">=3.9,<3.13"
 
 # Main dependencies
-keras = "<3.6.0"
+keras = "^3.3.3"
 numpy = [
     { version = "^1.23.5", markers = "python_version < \"3.12\"" },
     { version = "^1.26.0", markers = "python_version >= \"3.12\"" },

--- a/tests/layers/normalizations/test_rmsnorm.py
+++ b/tests/layers/normalizations/test_rmsnorm.py
@@ -1,14 +1,14 @@
 import numpy as np
+import pytest
 from einops import asnumpy, rearrange
 from keras import layers, models, ops
-import pytest
 
 from keras_mml.layers import RMSNorm
 
 
 # Calls
 def test_no_learnable_weights_1():
-    x = np.array([1, 2, 3])
+    x = np.array([1, 2, 3], dtype="float")
     y = RMSNorm(has_learnable_weights=False)(x)
     y_pred = asnumpy(y)
     y_true = np.array([0.46291004, 0.92582010, 1.38873015])
@@ -16,7 +16,7 @@ def test_no_learnable_weights_1():
 
 
 def test_no_learnable_weights_2():
-    x = np.array([4, -5, 6, -7])
+    x = np.array([4, -5, 6, -7], dtype="float")
     y = RMSNorm(has_learnable_weights=False)(x)
     y_pred = asnumpy(y)
     y_true = [0.71269665, -0.89087081, 1.06904497, -1.24721913]
@@ -24,7 +24,7 @@ def test_no_learnable_weights_2():
 
 
 def test_with_learnable_weights_1d():
-    x = np.array([1, 2, 3])
+    x = np.array([1, 2, 3], dtype="float")
     y = RMSNorm(use_bias=False)(x)
     assert ops.shape(y) == ops.shape(x)
 
@@ -33,7 +33,7 @@ def test_with_learnable_weights_1d():
 
 
 def test_with_learnable_weights_2d():
-    x = np.array([[1, 2, 3], [4, 5, 6]])
+    x = np.array([[1, 2, 3], [4, 5, 6]], dtype="float")
     y = RMSNorm(use_bias=False)(x)
     assert ops.shape(y) == ops.shape(x)
 
@@ -42,7 +42,9 @@ def test_with_learnable_weights_2d():
 
 
 def test_with_learnable_weights_3d():
-    x = np.array([[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]])
+    x = np.array(
+        [[[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]], [[1, 2, 3], [4, 5, 6]]], dtype="float"
+    )
     y = RMSNorm(use_bias=False)(x)
     assert ops.shape(y) == ops.shape(x)
 
@@ -58,7 +60,7 @@ def test_scale_access():
 # Training
 def test_training():
     # Dataset is just a sequence of known numbers
-    x = np.array([1, 2, 3, 4, 5])
+    x = np.array([1, 2, 3, 4, 5], dtype="float")
     x = rearrange(x, "(b f) -> b f", f=1)
     y = np.copy(x)
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes an issue with `test_rmsnorm.py` that causes the nightly build to fail on GitHub when using Keras 3.6.0 and above.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
